### PR TITLE
fix: exclude auth routes from middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,8 +1,5 @@
 export { default } from "next-auth/middleware";
 
 export const config = {
-  matcher: [
-    "/api/:path*",
-    // leave home public
-  ],
+  matcher: ["/api/(?!auth).*"], // match all API routes except NextAuth's
 };


### PR DESCRIPTION
## Summary
- adjust middleware matcher to ignore NextAuth routes

## Testing
- `npm run lint` *(fails: '`"' can be escaped with "&apos;", `&lsquo;`, `&#39;`, `&rsquo;`.  react/no-unescaped-entities` in app/blockouts/page.tsx, among others)*
- `npx eslint middleware.ts`


------
https://chatgpt.com/codex/tasks/task_e_68af71e60a1483219efae66eb4c86df2